### PR TITLE
chore: add CI, polish README, fix mypy strict errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Lint (ruff)
+        run: uv run ruff check src tests
+
+      - name: Type-check (mypy)
+        run: uv run mypy src
+
+      - name: Test (pytest)
+        run: uv run pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Restructured the root `README.md`: project-identity image at the top, less-technical opening paragraph and more-positive second paragraph, TL;DR-first Requirements (full details moved to a new "Requirements in detail" section linked from the TL;DR), Quick-start numbered list replaced with sub-sections and multi-line `docker` / `uv` commands, Modules table slimmed (dropped the redundant Archive column), "Commands" renamed to "Supported commands" with a `--help` pointer, and "What's already implemented" condensed from ten bullets to five. Configuration table rows for `SQL_REF`, `WORKDIR`, `MODULES` now include their defaults, plus a new row for `SQL_CACHE_DIR`.
+- Modules section: removed the Licence column (the linked [MusicBrainz Database / Download wiki page](https://wiki.musicbrainz.org/MusicBrainz_Database/Download) is the canonical source for per-archive licensing) and rewrote the Contents cells using the wiki's own wording — surfacing non-obvious bits the old one-liners hid (genres-via-tags in `derived`, the editor FK dependency, "metadata only — no images" for the art archives, the actual `wikidocs_index` table name, etc.). Moved the wiki pointer and `--modules` example to the section intro.
 
 ### Added
 
 - New "Splitting the connection string" sub-section under Configuration documents the libpq `PG*` env-var fallback pattern — e.g. `PGPASSWORD` supplied at runtime from a secret manager while host/port/user/database stay committed in `.env`.
 - `tests/unit/test_psql_env.py`: three unit tests covering `schema.psql._psql_env` — `PGPASSWORD` set from a password-bearing URL, passwordless URL leaves an inherited `PGPASSWORD` intact, and both-absent leaves `PGPASSWORD` out of the child env.
 - AGENTS.md rule: whenever a CLI command is added, renamed, removed, or its behaviour changes, the whole documentation surface must be reviewed (README sections beyond "Supported commands", `docs/features/`, AGENTS.md itself).
+- GitHub Actions CI workflow at `.github/workflows/ci.yml`: runs `ruff` → `mypy` → `pytest` under `uv sync --extra dev` on pushes to `main` and PRs into `main`. Matrix over Python 3.11 / 3.12 / 3.13 with `fail-fast: false`; a `concurrency` group cancels superseded PR runs to save Actions minutes.
+- README header badges (centered `<p>` below the tagline): CI status linking to the Actions runs page, supported Python versions (3.11 | 3.12 | 3.13), and MIT license.
+- README third intro paragraph noting this project came out of [RAGtime](https://github.com/rafacm/ragtime), where it stands up the local MusicBrainz mirror used by the [entity-resolution step](https://github.com/rafacm/ragtime/tree/main/doc#8--resolve-entities-status-resolving).
 
 ### Removed
 
 - `## Scope` section in the README. The "one-shot full imports only" line was already captured in AGENTS.md's "Out of scope for v1" list; the SQL-ref reproducibility tip ("pin to a `v-NN-schema-change` tag") moved into the Configuration table's `SQL_REF` row.
+
+### Fixed
+
+- Seven `mypy --strict` errors in `src/musicbrainz_database_setup/cli.py` and `src/musicbrainz_database_setup/progress.py`: typed the kwargs bag in `ProgressManager.update` as `dict[str, Any]` so `**unpack` reaches `rich.progress.Progress.update`'s heterogeneously-typed params; added narrow `# type: ignore[assignment]` on the two Typer `= ...` required-option defaults in `cli.import_` and `cli.verify_cmd` (idiom mypy can't model); annotated `cli._handle_errors() -> Iterator[None]`.
 
 ## 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
   <strong>MusicBrainz Data Dumps to PostgreSQL, in one beat</strong>
 </p>
 
+<p align="center">
+  <a href="https://github.com/rafacm/musicbrainz-database-setup/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/rafacm/musicbrainz-database-setup/actions/workflows/ci.yml/badge.svg" /></a>
+  <a href="https://www.python.org/downloads/"><img alt="Python 3.11 | 3.12 | 3.13" src="https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue.svg" /></a>
+  <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green.svg" /></a>
+</p>
+
+<br/>
+
 `musicbrainz-database-setup` is a Python CLI that sets up a full [MusicBrainz](https://musicbrainz.org/) database in a PostgreSQL instance of your choice. It downloads the official dumps from the MetaBrainz mirror, creates the [schema](https://wiki.musicbrainz.org/MusicBrainz_Database/Schema) by running the upstream `admin/sql/*.sql` [files](https://github.com/metabrainz/musicbrainz-server/tree/master/admin/sql) against your database, and loads the data straight from the archives into your database — with resumable downloads, verified integrity, and live progress for every table.
 
 This tool brings together the steps documented across the [MusicBrainz wiki](https://wiki.musicbrainz.org/MusicBrainz_Database/Download), the `musicbrainz-server` [admin Perl scripts](https://github.com/metabrainz/musicbrainz-server/tree/master/admin), and the [`metabrainz/musicbrainz-docker`](https://github.com/metabrainz/musicbrainz-docker) stack into a single command you can point at any PostgreSQL connection.

--- a/README.md
+++ b/README.md
@@ -75,24 +75,22 @@ For the full entity model and table-by-table reference, see the [MusicBrainz Dat
 
 ## Modules
 
-The MusicBrainz database is split across several `.tar.bz2` archives on the mirror. `--modules` (comma-separated) selects which to download and import. `core` is the default; the others are opt-in.
+The MusicBrainz database is split across several `.tar.bz2` archives on the mirror — enumerated canonically, with contents, licensing, and release cadence, on the [MusicBrainz Database / Download wiki page](https://wiki.musicbrainz.org/MusicBrainz_Database/Download).
 
-| Module | Target schema | Contents | Licence |
-|---|---|---|---|
-| `core` | `musicbrainz` | Artists, releases, recordings, works, labels, areas, places, events, series, instruments, URLs, genres. | [CC0](https://creativecommons.org/publicdomain/zero/1.0/) |
-| `derived` | `musicbrainz` | Annotations, ratings, tags, search helpers. | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/) |
-| `editor` | `musicbrainz` | Editor accounts. | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/) |
-| `edit` | `musicbrainz` | Edit history. | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/) |
-| `cover-art` | `cover_art_archive` | Cover Art Archive metadata. | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/) |
-| `event-art` | `event_art_archive` | Event Art Archive metadata. | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/) |
-| `stats` | `statistics` | Site statistics. | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/) |
-| `documentation` | `documentation` | Wiki documentation for entities. | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/) |
-| `wikidocs` | `wikidocs` | Stored wiki-docs tables. | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/) |
-| `cdstubs` | `musicbrainz` | CDStubs. | [CC0](https://creativecommons.org/publicdomain/zero/1.0/) |
+`--modules` (comma-separated) selects which to download and import; `core` is the default and the others are opt-in. Example: `--modules core,derived,cover-art`.
 
-Example: `--modules core,derived,cover-art`.
-
-The canonical enumeration of these archives — their contents, licensing, and release cadence — lives on the [MusicBrainz Database / Download wiki page](https://wiki.musicbrainz.org/MusicBrainz_Database/Download).
+| Module | Target schema | Contents |
+|---|---|---|
+| `core` | `musicbrainz` | Core MusicBrainz database — tables for Artist, Release, Recording, etc. Most catalog use cases only need this plus `derived`. |
+| `derived` | `musicbrainz` | Annotations, user ratings, user tags, and search indexes. Required for genre data (genres are stored as user tags). Annotations FK to editors, so add `editor` for standalone (non-mirror) setups. |
+| `editor` | `musicbrainz` | Non-personal user data about the people who enacted the edits in the edit history. |
+| `edit` | `musicbrainz` | Complete edit history for the core database — open and closed edits, edit notes, votes, and auto-editor elections. Editor identity comes from the `editor` dump. |
+| `cover-art` | `cover_art_archive` | Tables linking MusicBrainz to the [Cover Art Archive](https://wiki.musicbrainz.org/Cover_Art_Archive) (metadata only — no images). |
+| `event-art` | `event_art_archive` | Tables linking MusicBrainz to the [Event Art Archive](https://wiki.musicbrainz.org/Event_Art_Archive) (metadata only — no images). |
+| `stats` | `statistics` | Site statistics — the data behind [musicbrainz.org/statistics](https://musicbrainz.org/statistics). |
+| `documentation` | `documentation` | Tables specifying which relationships are used as examples for each relationship type, plus per-type guidelines where available. |
+| `wikidocs` | `wikidocs` | The `wikidocs_index` table — which revision is transcluded for each page in the [WikiDocs](https://wiki.musicbrainz.org/WikiDocs) system. |
+| `cdstubs` | `musicbrainz` | [CD Stubs](https://wiki.musicbrainz.org/CD_Stub) — anonymously submitted, treated as an untrusted source kept separate from the core database. |
 
 ## Supported commands
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 This tool brings together the steps documented across the [MusicBrainz wiki](https://wiki.musicbrainz.org/MusicBrainz_Database/Download), the `musicbrainz-server` [admin Perl scripts](https://github.com/metabrainz/musicbrainz-server/tree/master/admin), and the [`metabrainz/musicbrainz-docker`](https://github.com/metabrainz/musicbrainz-docker) stack into a single command you can point at any PostgreSQL connection.
 
+This project came out of [RAGtime](https://github.com/rafacm/ragtime) to be used in the [entity-resolution step](https://github.com/rafacm/ragtime/tree/main/doc#8--resolve-entities-status-resolving) to map extracted mentions to canonical MusicBrainz entities.
+
 ## Requirements
 
 - PostgreSQL **16 or later** — any official [`postgres:*` Docker image](https://hub.docker.com/_/postgres) satisfies every server-side requirement out of the box.

--- a/src/musicbrainz_database_setup/cli.py
+++ b/src/musicbrainz_database_setup/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Annotated
@@ -225,7 +226,7 @@ def import_(
     dump_dir: Annotated[
         Path,
         typer.Option("--dump-dir", help="Local directory containing the .tar.bz2 archives."),
-    ] = ...,
+    ] = ...,  # type: ignore[assignment]
     modules: ModulesOption = "core",
     force: Annotated[bool, typer.Option("--force-reimport")] = False,
 ) -> None:
@@ -281,7 +282,7 @@ def run(
 
 @app.command("verify")
 def verify_cmd(
-    dump_dir: Annotated[Path, typer.Option("--dump-dir")] = ...,
+    dump_dir: Annotated[Path, typer.Option("--dump-dir")] = ...,  # type: ignore[assignment]
     modules: ModulesOption = "core",
 ) -> None:
     """Print SCHEMA_SEQUENCE + REPLICATION_SEQUENCE from each archive."""
@@ -323,7 +324,7 @@ def clean(
 
 
 @contextmanager
-def _handle_errors():
+def _handle_errors() -> Iterator[None]:
     try:
         yield
     except MBSetupError as exc:

--- a/src/musicbrainz_database_setup/progress.py
+++ b/src/musicbrainz_database_setup/progress.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any
 
 from rich.progress import (
     BarColumn,
@@ -85,7 +86,7 @@ class ProgressManager:
         description: str | None = None,
         note: str | None = None,
     ) -> None:
-        kwargs: dict[str, object] = {}
+        kwargs: dict[str, Any] = {}
         if completed is not None:
             kwargs["completed"] = completed
         if total is not None:


### PR DESCRIPTION
## Summary

Housekeeping bundle — no user-facing behavior change.

- **CI** — new `.github/workflows/ci.yml` runs `ruff` → `mypy` → `pytest` via `uv sync --extra dev` on pushes to `main` and PRs into `main`. Matrix over Python 3.11 / 3.12 / 3.13 with `fail-fast: false`; a `concurrency` group cancels superseded PR runs.
- **README badges** — CI status, Python versions, MIT license (centered `<p>` below the tagline).
- **README Modules section** — dropped the Licence column (the linked wiki page is the canonical source for licensing) and rewrote each Contents cell using the wiki's own wording, surfacing non-obvious details (genres-via-tags in `derived`, editor FK dependency, "metadata only — no images" for the art archives, the `wikidocs_index` table name, etc.). Wiki pointer + `--modules` example moved to the section intro.
- **README origin note** — third intro paragraph pointing at [RAGtime](https://github.com/rafacm/ragtime)'s entity-resolution step, which is the downstream consumer of the mirror this tool sets up.
- **mypy** — cleared seven `--strict` errors in `cli.py` and `progress.py`: `dict[str, Any]` for the kwargs bag in `ProgressManager.update`, narrow `# type: ignore[assignment]` on the two Typer `= ...` required-option defaults (idiom mypy can't model), and `_handle_errors() -> Iterator[None]`.

`CHANGELOG.md` updated under the existing `2026-04-24` section. No `docs/plans/` or `docs/features/` entries — none of these changes meet the "feature or significant change" bar from AGENTS.md's Documentation section. Happy to add them if you want.

## Test plan

- [x] `uv run ruff check src tests` — clean locally
- [x] `uv run mypy src` — clean locally (was 7 errors)
- [x] `uv run pytest` — 23 passed locally
- [x] CI turns green on all three Python versions after push
- [x] README renders correctly on GitHub (badges, updated Modules table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)