### PR TITLE
docs(readme): slim for DX; move long-form to docs/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ uv run musicbrainz-database-setup run \
 
 If neither `--latest` nor `--date YYYYMMDD-HHMMSS` is passed, `run` interactively prompts for a dump directory from the mirror.
 
-Every flag has an env-var equivalent, and standard `PG*` libpq vars apply to the connection string. See [Configuration](docs/README.md#configuration) in the reference guide for the full list and how to keep the password out of the URL.
+The main configuration options have `MUSICBRAINZ_DATABASE_SETUP_*` env-var equivalents, and standard `PG*` libpq vars apply to the connection string. See [Configuration](docs/README.md#configuration) in the reference guide for the full list and how to keep the password out of the URL.
 
 ### 4. Explore the data
 
@@ -164,7 +164,7 @@ uv run mypy src
 
 ## Credits
 
-This tool stands on the work of the [MusicBrainz](https://musicbrainz.org/), [MetaBrainz](https://metabrainz.org/), and [acoustid](https://acoustid.org/) communities. It automates the steps documented across the MusicBrainz wiki and the upstream [`musicbrainz-server/admin`](https://github.com/metabrainz/musicbrainz-server/tree/master/admin) Perl scripts into a single command you can point at any PostgreSQL connection — local Docker, managed (RDS, Cloud SQL), or anything else that speaks libpq. 
+This tool stands on the work of the [MusicBrainz](https://musicbrainz.org/), [MetaBrainz](https://metabrainz.org/), and [acoustid](https://acoustid.org/) communities. It automates the steps documented across the MusicBrainz wiki and the upstream [`musicbrainz-server/admin`](https://github.com/metabrainz/musicbrainz-server/tree/master/admin) Perl scripts into a single command you can point at any PostgreSQL connection — local Docker, managed (RDS, Cloud SQL), or anything else that speaks libpq.
 
 See [docs/README.md → References](docs/README.md#references) for the full list of upstream sources.
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 
 <br/>
 
-`musicbrainz-database-setup` is a Python CLI that sets up a full [MusicBrainz](https://musicbrainz.org/) database in a PostgreSQL instance of your choice. It downloads the official dumps from the MetaBrainz mirror, creates the [schema](https://wiki.musicbrainz.org/MusicBrainz_Database/Schema) by running the upstream `admin/sql/*.sql` [files](https://github.com/metabrainz/musicbrainz-server/tree/master/admin/sql) against your database, and loads the data straight from the archives into your database — with resumable downloads, verified integrity, and live progress for every table.
+`musicbrainz-database-setup` is a Python CLI that sets up a full [MusicBrainz](https://musicbrainz.org/) database in PostgreSQL. Point it at a connection string and a dump, and it handles the rest: resumable, SHA256-verified downloads from the [MetaBrainz mirror](https://wiki.musicbrainz.org/MusicBrainz_Database/Download), schema creation via the upstream [`admin/sql/*.sql`](https://github.com/metabrainz/musicbrainz-server/tree/master/admin/sql) files, and streaming `COPY` of every table with live progress.
 
-This tool brings together the steps documented across the [MusicBrainz wiki](https://wiki.musicbrainz.org/MusicBrainz_Database/Download), the `musicbrainz-server` [admin Perl scripts](https://github.com/metabrainz/musicbrainz-server/tree/master/admin), and the [`metabrainz/musicbrainz-docker`](https://github.com/metabrainz/musicbrainz-docker) stack into a single command you can point at any PostgreSQL connection.
+It automates the steps documented across the MusicBrainz wiki and the upstream [`musicbrainz-server/admin`](https://github.com/metabrainz/musicbrainz-server/tree/master/admin) Perl scripts into a single command you can point at any PostgreSQL connection — local Docker, managed (RDS, Cloud SQL), or anything else that speaks libpq.
 
-This project came out of [RAGtime](https://github.com/rafacm/ragtime) to be used in the [entity-resolution step](https://github.com/rafacm/ragtime/tree/main/doc#8--resolve-entities-status-resolving) to map extracted mentions to canonical MusicBrainz entities.
+This project originated from [RAGtime](https://github.com/rafacm/ragtime), where it powers the [entity-resolution step](https://github.com/rafacm/ragtime/tree/main/doc#8--resolve-entities-status-resolving) that maps extracted mentions to canonical MusicBrainz entities.
 
 ## Requirements
 
@@ -26,9 +26,8 @@ This project came out of [RAGtime](https://github.com/rafacm/ragtime) to be used
 - A role with **`SUPERUSER`** on the target DB (the default `postgres` user works).
 - **`psql`** on your `$PATH` on the machine running the tool.
 - **`pbzip2`** (or **`lbzip2`**) on `$PATH` *(optional, recommended)* — parallelises bz2 decompression during COPY, the single biggest phase of a fresh import. Without it the tool falls back to CPython's single-threaded stdlib `bz2`.
-- **~30 GB** of free disk for `core + derived` downloads; **~160 GB** for the live DB once indexes are built.
 
-See [Requirements in detail](#requirements-in-detail) for the full list, including managed-PostgreSQL notes.
+See [docs/README.md](docs/README.md) for the full setup guide — extensions, ICU, server-side tuning, disk/memory, and managed-PostgreSQL notes.
 
 ## Quick start
 
@@ -44,7 +43,7 @@ docker run -d \
   postgres:17-alpine
 ```
 
-> 💡 **Want a faster import?** Add server-start tuning flags (`shared_buffers`, `max_wal_size`, `checkpoint_timeout`, …) to roughly halve post-import DDL time. See [PostgreSQL server-side tuning (optional)](#postgresql-server-side-tuning-optional) for the tuned `docker run` and per-flag rationale.
+> 💡 **Want a faster import?** Add server-start tuning flags (`shared_buffers`, `max_wal_size`, `checkpoint_timeout`, …) to roughly halve post-import DDL time. See [PostgreSQL server-side tuning](docs/README.md#postgresql-server-side-tuning-optional) for the tuned `docker run` and per-flag rationale.
 
 ### Install the CLI
 
@@ -67,10 +66,10 @@ If neither `--latest` nor `--date YYYYMMDD-HHMMSS` is passed, `run` interactivel
 
 ### Poke around the imported data
 
-Open a psql session against the running container and run a couple of sanity queries:
+Open a psql session against the database and run a couple of sanity queries:
 
 ```bash
-docker exec -it musicbrainz-postgres psql -U postgres -d postgres
+psql postgresql://postgres:postgres@localhost:5432/postgres
 ```
 
 ```sql
@@ -79,31 +78,46 @@ SELECT
   (SELECT count(*) FROM musicbrainz.artist)    AS artists,
   (SELECT count(*) FROM musicbrainz.release)   AS releases,
   (SELECT count(*) FROM musicbrainz.recording) AS recordings;
+```
 
--- Look up an artist by name (gid is the MusicBrainz ID / MBID)
-SELECT gid, name, sort_name FROM musicbrainz.artist WHERE name = 'The Beatles';
+Look up [Django Reinhardt](https://musicbrainz.org/artist/650bf385-6f6d-4992-a3b9-779d144920a4) by his MBID (his Wikidata ID is [Q44122](https://www.wikidata.org/wiki/Q44122)) — joining `artist` to `gender`, `artist_type`, and `area` for the human-readable details:
+
+```sql
+SELECT
+  a.gid,
+  a.name,
+  a.sort_name,
+  g.name           AS gender,
+  at.name          AS type,
+  a.begin_date_year,
+  a.end_date_year,
+  birth_area.name  AS birth_area,
+  a.comment
+FROM musicbrainz.artist a
+LEFT JOIN musicbrainz.gender      g          ON a.gender = g.id
+LEFT JOIN musicbrainz.artist_type at         ON a.type   = at.id
+LEFT JOIN musicbrainz.area        birth_area ON a.area   = birth_area.id
+WHERE a.gid = '650bf385-6f6d-4992-a3b9-779d144920a4';
+```
+
+…and his external links via the URL relationship system (`l_artist_url` → `link` → `link_type` → `url`) — Wikidata, Discogs, allmusic, last.fm, IMDb, and many more:
+
+```sql
+SELECT lt.name AS link_type, u.url
+FROM musicbrainz.l_artist_url lau
+JOIN musicbrainz.artist    a  ON lau.entity0 = a.id
+JOIN musicbrainz.link      l  ON lau.link    = l.id
+JOIN musicbrainz.link_type lt ON l.link_type = lt.id
+JOIN musicbrainz.url       u  ON lau.entity1 = u.id
+WHERE a.gid = '650bf385-6f6d-4992-a3b9-779d144920a4'
+ORDER BY lt.name;
 ```
 
 For the full entity model and table-by-table reference, see the [MusicBrainz Database](https://musicbrainz.org/doc/MusicBrainz_Database) and [Database Schema](https://musicbrainz.org/doc/MusicBrainz_Database/Schema) docs.
 
 ## Modules
 
-The MusicBrainz database is split across several `.tar.bz2` archives on the mirror — enumerated canonically, with contents, licensing, and release cadence, on the [MusicBrainz Database / Download wiki page](https://wiki.musicbrainz.org/MusicBrainz_Database/Download).
-
-`--modules` (comma-separated) selects which to download and import; `core` is the default and the others are opt-in. Example: `--modules core,derived,cover-art`.
-
-| Module | Target schema | Contents |
-|---|---|---|
-| `core` | `musicbrainz` | Core MusicBrainz database — tables for Artist, Release, Recording, etc. Most catalog use cases only need this plus `derived`. |
-| `derived` | `musicbrainz` | Annotations, user ratings, user tags, and search indexes. Required for genre data (genres are stored as user tags). Annotations FK to editors, so add `editor` for standalone (non-mirror) setups. |
-| `editor` | `musicbrainz` | Non-personal user data about the people who enacted the edits in the edit history. |
-| `edit` | `musicbrainz` | Complete edit history for the core database — open and closed edits, edit notes, votes, and auto-editor elections. Editor identity comes from the `editor` dump. |
-| `cover-art` | `cover_art_archive` | Tables linking MusicBrainz to the [Cover Art Archive](https://wiki.musicbrainz.org/Cover_Art_Archive) (metadata only — no images). |
-| `event-art` | `event_art_archive` | Tables linking MusicBrainz to the [Event Art Archive](https://wiki.musicbrainz.org/Event_Art_Archive) (metadata only — no images). |
-| `stats` | `statistics` | Site statistics — the data behind [musicbrainz.org/statistics](https://musicbrainz.org/statistics). |
-| `documentation` | `documentation` | Tables specifying which relationships are used as examples for each relationship type, plus per-type guidelines where available. |
-| `wikidocs` | `wikidocs` | The `wikidocs_index` table — which revision is transcluded for each page in the [WikiDocs](https://wiki.musicbrainz.org/WikiDocs) system. |
-| `cdstubs` | `musicbrainz` | [CD Stubs](https://wiki.musicbrainz.org/CD_Stub) — anonymously submitted, treated as an untrusted source kept separate from the core database. |
+Pass `--modules core,derived,…` (comma-separated) to select which `.tar.bz2` archives to download and import. Default is `core`; the others are opt-in. See [available modules](docs/README.md#modules) for the full list and what each contains.
 
 ## Supported commands
 
@@ -118,36 +132,6 @@ Run `uv run musicbrainz-database-setup --help` to see the available commands and
 - `clean` — remove cached downloads.
 
 The end-to-end `run` is structured as five phases — **Locate dump → Download → Schema setup → Import tables → Schema finalize** — each preceded by a `==> Phase N/5 · <label>` banner (Homebrew-style prefix) and closed by a `✓ <label> complete · <elapsed>` footer so the transcript shows where you are at a glance. Inside each phase, the body logs the mirror URL + resolved dump, the file list being downloaded, each `admin/sql/*.sql` applied (with `(N/total)` count prefix), and each COPY'd table by schema-qualified name. Standalone subcommands map to the relevant subset (`download` covers Locate dump + Download; `schema create --phase pre/post/all` covers Schema setup / Schema finalize; `import` covers Import tables). Routine progress lines have no level prefix (matching brew / cargo conventions); `Warning:` / `Error:` records keep an explicit text label so severity stays readable even with `--no-color`. Pass `-v` / `--verbose` to surface the underlying `httpx` HTTP requests and the rest of the DEBUG-level chatter; default output stays focused on phase progress.
-
-## Configuration
-
-Precedence: CLI flags > env vars > `.env` file > defaults.
-
-| Variable | Meaning |
-|---|---|
-| `MUSICBRAINZ_DATABASE_SETUP_DB_URL` | libpq connection URL |
-| `MUSICBRAINZ_DATABASE_SETUP_MIRROR_URL` | Base URL of the dump mirror |
-| `MUSICBRAINZ_DATABASE_SETUP_SQL_REF` | Git ref (branch/tag/SHA) for the `admin/sql/*.sql` fetch. Default `master`; pin to a `v-NN-schema-change` tag for reproducibility. |
-| `MUSICBRAINZ_DATABASE_SETUP_WORKDIR` | Local cache dir for archive downloads. Default `${XDG_CACHE_HOME:-~/.cache}/musicbrainz-database-setup/dumps`. |
-| `MUSICBRAINZ_DATABASE_SETUP_SQL_CACHE_DIR` | Local cache dir for fetched `admin/sql/*.sql` files, keyed by resolved commit SHA. Default `${XDG_CACHE_HOME:-~/.cache}/musicbrainz-database-setup/sql`. |
-| `MUSICBRAINZ_DATABASE_SETUP_MODULES` | Comma-separated list of modules to download and import (e.g. `core,derived,cover-art`). See [Modules](#modules). Default `core`. |
-
-### Splitting the connection string
-
-libpq (used by both psycopg3 and `psql`) natively honors the `PG*` environment variables — values omitted from the connection URL fall back to them. This lets you keep connection coordinates and secrets in separate places. Hard-code host/port/user/database in a committed `.env`:
-
-```bash
-MUSICBRAINZ_DATABASE_SETUP_DB_URL=postgresql://postgres@localhost:5432/postgres
-```
-
-…and supply the password at runtime from a secret manager or your shell:
-
-```bash
-PGPASSWORD="$(op read op://work/musicbrainz/password)" \
-  uv run musicbrainz-database-setup run --latest
-```
-
-Any libpq [environment variable](https://www.postgresql.org/docs/current/libpq-envars.html) works the same way (`PGSSLMODE`, `PGSSLROOTCERT`, `PGCONNECT_TIMEOUT`, …).
 
 ## Status
 
@@ -177,56 +161,6 @@ uv run pytest
 uv run ruff check src tests
 uv run mypy src
 ```
-
-## Requirements in detail
-
-### PostgreSQL server
-
-PostgreSQL **16 or later** with:
-
-- The **`cube`**, **`earthdistance`**, and **`unaccent`** extensions — declared in upstream [`admin/sql/Extensions.sql`](https://github.com/metabrainz/musicbrainz-server/blob/master/admin/sql/Extensions.sql). They ship with the `postgresql-contrib` package, which is bundled in every official [`postgres:*` Docker image](https://hub.docker.com/_/postgres).
-- **ICU support** (server built with `--with-icu`). The MusicBrainz collation in [`admin/sql/CreateCollations.sql`](https://github.com/metabrainz/musicbrainz-server/blob/master/admin/sql/CreateCollations.sql) uses `provider = icu`. Every official `postgres:*` image since PG 16 qualifies.
-- A role with **`SUPERUSER`** privileges so the tool can `CREATE EXTENSION`. The default `postgres` user created by the official image works.
-
-The tool pre-flights `pg_available_extensions` and `pg_collation` at startup and aborts with an actionable message if anything is missing.
-
-The tool also works against managed PostgreSQL (RDS, Cloud SQL, etc.) as long as the role you connect as can `CREATE EXTENSION` (on RDS that's `rds_superuser`; on Cloud SQL, `postgres`).
-
-### PostgreSQL server-side tuning (optional)
-
-Stock Postgres defaults (`shared_buffers=128 MB`, `maintenance_work_mem=64 MB`, `synchronous_commit=on`, `max_wal_size=1 GB`) leave significant performance on the table during index builds and constraint validation. The tool sets per-session tuning via `PGOPTIONS` for every `admin/sql/*.sql` invocation, but a handful of knobs can only be set at server start. If you're spinning up the Postgres container yourself, the following flags roughly halve post-import DDL time:
-
-```bash
-docker run -d --name musicbrainz-postgres \
-  -e POSTGRES_PASSWORD=postgres \
-  -p 5432:5432 \
-  postgres:17-alpine \
-  -c shared_buffers=2GB \
-  -c max_wal_size=8GB \
-  -c checkpoint_timeout=30min \
-  -c effective_io_concurrency=200 \
-  -c random_page_cost=1.1
-```
-
-- `shared_buffers=2GB` — default 128 MB forces constant disk re-reads during CHECK/FK full-table scans; at 2 GB the hot tables fit in cache without starving the rest of the 8 GB Docker Desktop VM. (If your VM has more RAM, you can safely push this to `4GB`.)
-- `max_wal_size=8GB` + `checkpoint_timeout=30min` — default 1 GB / 5 min triggers checkpoints every couple of minutes during COPY.
-- `effective_io_concurrency=200` + `random_page_cost=1.1` — signal to the planner that the underlying storage (Docker named volume on SSD) isn't a spinning disk.
-
-> ⚠️ **Memory sizing.** The tool applies `maintenance_work_mem=1GB` per psql session during DDL, and CREATE INDEX can fan out to `1 + max_parallel_maintenance_workers` workers each using that budget — up to **5 GB peak** on a single statement. Combined with `shared_buffers=2GB` above, that's ~7 GB of Postgres's own memory, fitting an 8 GB Docker Desktop VM with headroom for the OS and page cache. Raising `shared_buffers` beyond 2 GB on an 8 GB VM risks OOM kills during `CreateFKConstraints.sql` / `CreateConstraints.sql` — we hit this on 2026-04-24 with `shared_buffers=4GB`.
-
-### PostgreSQL client (`psql`)
-
-The **`psql` client** must be available on `$PATH` on the machine running the tool. The upstream `admin/sql/*.sql` files use psql meta-commands (`\set ON_ERROR_STOP 1`, etc.) and manage their own `BEGIN;/COMMIT;` — we shell out to `psql` for each file, mirroring `admin/InitDb.pl`'s own approach, rather than reimplementing that parsing in Python. Install it with `brew install libpq` (macOS), `apt install postgresql-client` (Debian/Ubuntu), `apk add postgresql-client` (Alpine), or the equivalent on your distro.
-
-### Parallel bz2 decompression (`pbzip2` / `lbzip2`, optional)
-
-MusicBrainz dumps ship as `.tar.bz2`, and CPython's stdlib `bz2` module is single-threaded — the decompressor tops out around 35 MB/s of compressed input on a modern laptop, which pins one Python core at 100% and leaves the Postgres backend waiting on `Client/ClientRead` for most of the COPY phase. On a 14-core machine this made COPY the dominant cost of a fresh core-module import (14 m of 27 m total). If **`pbzip2`** or **`lbzip2`** is on `$PATH`, `open_archive()` pipes the archive through it instead, so decompression runs across multiple cores and the bottleneck shifts to Postgres (where it belongs). Install with `brew install pbzip2` (macOS), `apt install pbzip2` (Debian/Ubuntu), or `apk add pbzip2` (Alpine). If neither is present the tool falls back to the stdlib decompressor transparently — nothing fails, just slower.
-
-### Disk and memory
-
-Expect **~10–15 GB** of downloads for `core`, **~30 GB** for `core + derived`, and the live database grows to roughly **100–160 GB** once indexes are built. More if `cover-art` or `event-art` are selected.
-
-Memory is comfortable at **8 GB** for the Postgres container with the tuning above (`shared_buffers=2GB` + the per-session `maintenance_work_mem=1GB` applied during DDL); **16 GB** if you're running the client and the database on the same machine. CPython's stdlib `bz2` fallback adds no client-side memory pressure; `pbzip2` uses a small fixed buffer per thread.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -121,15 +121,15 @@ Pass `--modules core,derived,…` (comma-separated) to select which `.tar.bz2` a
 
 Run `uv run musicbrainz-database-setup --help` to see the available commands and options at any time.
 
-- `list-dumps` — print the dated dump directories on the mirror.
-- `download` — fetch the selected archives (SHA256-verified, resumable).
-- `schema create` — fetch `admin/sql/*.sql` at `--ref` and apply pre- and/or post-import DDL.
-- `import` — stream TSVs from a local `--dump-dir` through `COPY FROM STDIN`.
-- `run` — end-to-end: pick or resolve a dump, download, pre-DDL, import, post-DDL, `VACUUM ANALYZE`.
-- `verify` — print `SCHEMA_SEQUENCE` / `REPLICATION_SEQUENCE` for each local archive.
-- `clean` — remove cached downloads.
+- `list-dumps`: print the dated dump directories on the mirror.
+- `download`: fetch the selected archives (SHA256-verified, resumable).
+- `schema create`: fetch `admin/sql/*.sql` at `--ref` and apply pre- and/or post-import DDL.
+- `import`: stream TSVs from a local `--dump-dir` through `COPY FROM STDIN`.
+- `run`: end-to-end — pick or resolve a dump, download, pre-DDL, import, post-DDL, `VACUUM ANALYZE`.
+- `verify`: print `SCHEMA_SEQUENCE` / `REPLICATION_SEQUENCE` for each local archive.
+- `clean`: remove cached downloads.
 
-The end-to-end `run` is structured as five phases — **Locate dump → Download → Schema setup → Import tables → Schema finalize** — each preceded by a `==> Phase N/5 · <label>` banner (Homebrew-style prefix) and closed by a `✓ <label> complete · <elapsed>` footer so the transcript shows where you are at a glance. Inside each phase, the body logs the mirror URL + resolved dump, the file list being downloaded, each `admin/sql/*.sql` applied (with `(N/total)` count prefix), and each COPY'd table by schema-qualified name. Standalone subcommands map to the relevant subset (`download` covers Locate dump + Download; `schema create --phase pre/post/all` covers Schema setup / Schema finalize; `import` covers Import tables). Routine progress lines have no level prefix (matching brew / cargo conventions); `Warning:` / `Error:` records keep an explicit text label so severity stays readable even with `--no-color`. Pass `-v` / `--verbose` to surface the underlying `httpx` HTTP requests and the rest of the DEBUG-level chatter; default output stays focused on phase progress.
+See [Progress output](docs/README.md#progress-output) in `docs/README.md` for the 5-phase breakdown of `run` and the per-phase output format.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@
 
 `musicbrainz-database-setup` is a Python CLI that sets up a full [MusicBrainz](https://musicbrainz.org/) database in PostgreSQL. Point it at a connection string and a dump, and it handles the rest: resumable, SHA256-verified downloads from the [MetaBrainz mirror](https://wiki.musicbrainz.org/MusicBrainz_Database/Download), schema creation via the upstream [`admin/sql/*.sql`](https://github.com/metabrainz/musicbrainz-server/tree/master/admin/sql) files, and streaming `COPY` of every table with live progress.
 
-It automates the steps documented across the MusicBrainz wiki and the upstream [`musicbrainz-server/admin`](https://github.com/metabrainz/musicbrainz-server/tree/master/admin) Perl scripts into a single command you can point at any PostgreSQL connection — local Docker, managed (RDS, Cloud SQL), or anything else that speaks libpq.
-
 This project originated from [RAGtime](https://github.com/rafacm/ragtime), where it powers the [entity-resolution step](https://github.com/rafacm/ragtime/tree/main/doc#8--resolve-entities-status-resolving) that maps extracted mentions to canonical MusicBrainz entities.
 
 ## Requirements
@@ -164,7 +162,9 @@ uv run mypy src
 
 ## Credits
 
-This tool stands on the work of the MusicBrainz, MetaBrainz, and acoustid communities. See [docs/README.md → References](docs/README.md#references) for the full list of upstream sources.
+This tool stands on the work of the [MusicBrainz](https://musicbrainz.org/), [MetaBrainz](https://metabrainz.org/), and [acoustid](https://acoustid.org/) communities. It automates the steps documented across the MusicBrainz wiki and the upstream [`musicbrainz-server/admin`](https://github.com/metabrainz/musicbrainz-server/tree/master/admin) Perl scripts into a single command you can point at any PostgreSQL connection — local Docker, managed (RDS, Cloud SQL), or anything else that speaks libpq. 
+
+See [docs/README.md → References](docs/README.md#references) for the full list of upstream sources.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker run -d \
   postgres:17-alpine
 ```
 
-> 💡 **Want a faster import?** Add server-start tuning flags (`shared_buffers`, `max_wal_size`, `checkpoint_timeout`, …) to roughly halve post-import DDL time. See [PostgreSQL server-side tuning](docs/README.md#postgresql-server-side-tuning-optional) for the tuned `docker run` and per-flag rationale.
+> 💡 **Want a faster import?** Add server-start tuning flags (`shared_buffers`, `max_wal_size`, `checkpoint_timeout`, …) to roughly halve post-import DDL time. See [Server-side tuning](docs/README.md#server-side-tuning-optional) in the reference guide for the tuned `docker run` and per-flag rationale.
 
 ### Install the CLI
 
@@ -129,7 +129,7 @@ Run `uv run musicbrainz-database-setup --help` to see the available commands and
 - `verify`: print `SCHEMA_SEQUENCE` / `REPLICATION_SEQUENCE` for each local archive.
 - `clean`: remove cached downloads.
 
-See [Progress output](docs/README.md#progress-output) in `docs/README.md` for the 5-phase breakdown of `run` and the per-phase output format.
+Pass `-v` / `--verbose` on any of these commands to surface the underlying DEBUG-level output (`httpx` HTTP requests and the rest of the chatter); the default transcript stays focused on high-level phase progress.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [docs/README.md](docs/README.md) for the full setup guide — extensions, IC
 
 ## Quick start
 
-### Start a Postgres instance
+### 1. Start Postgres
 
 Any official `postgres:*` image works. `--name` is the Docker container name (for `docker exec` / `docker stop`); the database name used by the tool is `postgres`, the default created by the image's entrypoint.
 
@@ -43,13 +43,13 @@ docker run -d \
 
 > 💡 **Want a faster import?** Add server-start tuning flags (`shared_buffers`, `max_wal_size`, `checkpoint_timeout`, …) to roughly halve post-import DDL time. See [Server-side tuning](docs/README.md#server-side-tuning-optional) in the reference guide for the tuned `docker run` and per-flag rationale.
 
-### Install the CLI
+### 2. Install the CLI
 
 ```bash
 uv sync
 ```
 
-### Download, create the schema, import, and finalise, end-to-end
+### 3. Import the database
 
 Connection string is `postgresql://<user>:<password>@<host>:<port>/<database>`.
 
@@ -64,7 +64,7 @@ If neither `--latest` nor `--date YYYYMMDD-HHMMSS` is passed, `run` interactivel
 
 Every flag has an env-var equivalent, and standard `PG*` libpq vars apply to the connection string. See [Configuration](docs/README.md#configuration) in the reference guide for the full list and how to keep the password out of the URL.
 
-### Poke around the imported data
+### 4. Explore the data
 
 Open a psql session against the database and run a couple of sanity queries:
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ uv run musicbrainz-database-setup run \
 
 If neither `--latest` nor `--date YYYYMMDD-HHMMSS` is passed, `run` interactively prompts for a dump directory from the mirror.
 
+Every flag has an env-var equivalent, and standard `PG*` libpq vars apply to the connection string. See [Configuration](docs/README.md#configuration) in the reference guide for the full list and how to keep the password out of the URL.
+
 ### Poke around the imported data
 
 Open a psql session against the database and run a couple of sanity queries:

--- a/README.md
+++ b/README.md
@@ -162,31 +162,9 @@ uv run ruff check src tests
 uv run mypy src
 ```
 
-## References
+## Credits
 
-This tool is built on the following primary sources.
-
-### MusicBrainz documentation
-
-- [**Database / Download**](https://wiki.musicbrainz.org/MusicBrainz_Database/Download): mirror layout, dump cadence, checksum/signature files.
-- [**Database / Schema**](https://wiki.musicbrainz.org/MusicBrainz_Database/Schema): PG version and extension requirements.
-- [**MusicBrainz Entity**](https://musicbrainz.org/doc/MusicBrainz_Entity): the entity model and which entities are core vs derived.
-- [**Development / JSON Data Dumps**](https://musicbrainz.org/doc/Development/JSON_Data_Dumps): JSON dump format (out of scope for this tool).
-
-### Upstream code
-
-- [**`metabrainz/musicbrainz-server/admin/sql/`**](https://github.com/metabrainz/musicbrainz-server/tree/master/admin/sql): the canonical DDL this tool applies (`Extensions.sql`, `CreateCollations.sql`, `CreateTypes.sql`, `CreateTables.sql`, …, `CreateTriggers.sql`).
-- [**`metabrainz/musicbrainz-server/admin/`**](https://github.com/metabrainz/musicbrainz-server/tree/master/admin): `InitDb.pl` (authoritative DDL phase order) and `MBImport.pl` (reference for the COPY loop).
-- [**`metabrainz/musicbrainz-docker`**](https://github.com/metabrainz/musicbrainz-docker): upstream's official Docker-compose stack. A useful reference for how upstream provisions Postgres, but not a dependency of this tool.
-
-### Related Python tools
-
-- [**`acoustid/mbslave`**](https://github.com/acoustid/mbslave): Lukas Lalinsky's Python tool that handles both initial import and ongoing replication.
-- [**`acoustid/mbdata`**](https://github.com/acoustid/mbdata): SQLAlchemy models for the MusicBrainz schema. Complementary to this tool.
-
-### PostgreSQL
-
-- [**`postgres` Docker image**](https://hub.docker.com/_/postgres): the official image used in the Quick start.
+This tool stands on the work of the MusicBrainz, MetaBrainz, and acoustid communities. See [docs/README.md → References](docs/README.md#references) for the full list of upstream sources.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,23 @@
 
 Long-form companion to the [project README](../README.md). Everything here is reference material — the README covers the quick-start path; this file covers what you need once you outgrow it.
 
+## Contents
+
+- [Requirements in detail](#requirements-in-detail)
+  - [PostgreSQL server](#postgresql-server)
+  - [PostgreSQL server-side tuning (optional)](#postgresql-server-side-tuning-optional)
+  - [PostgreSQL client (`psql`)](#postgresql-client-psql)
+  - [Parallel bz2 decompression (`pbzip2` / `lbzip2`, optional)](#parallel-bz2-decompression-pbzip2--lbzip2-optional)
+  - [Disk and memory](#disk-and-memory)
+- [Modules](#modules)
+- [Configuration](#configuration)
+  - [Splitting the connection string](#splitting-the-connection-string)
+- [References](#references)
+  - [MusicBrainz documentation](#musicbrainz-documentation)
+  - [Upstream code](#upstream-code)
+  - [Related Python tools](#related-python-tools)
+  - [PostgreSQL](#postgresql)
+
 ## Requirements in detail
 
 ### PostgreSQL server
@@ -100,3 +117,29 @@ PGPASSWORD="$(op read op://work/musicbrainz/password)" \
 ```
 
 Any libpq [environment variable](https://www.postgresql.org/docs/current/libpq-envars.html) works the same way (`PGSSLMODE`, `PGSSLROOTCERT`, `PGCONNECT_TIMEOUT`, …).
+
+## References
+
+This tool is built on the following primary sources.
+
+### MusicBrainz documentation
+
+- [**Database / Download**](https://wiki.musicbrainz.org/MusicBrainz_Database/Download): mirror layout, dump cadence, checksum/signature files.
+- [**Database / Schema**](https://wiki.musicbrainz.org/MusicBrainz_Database/Schema): PG version and extension requirements.
+- [**MusicBrainz Entity**](https://musicbrainz.org/doc/MusicBrainz_Entity): the entity model and which entities are core vs derived.
+- [**Development / JSON Data Dumps**](https://musicbrainz.org/doc/Development/JSON_Data_Dumps): JSON dump format (out of scope for this tool).
+
+### Upstream code
+
+- [**`metabrainz/musicbrainz-server/admin/sql/`**](https://github.com/metabrainz/musicbrainz-server/tree/master/admin/sql): the canonical DDL this tool applies (`Extensions.sql`, `CreateCollations.sql`, `CreateTypes.sql`, `CreateTables.sql`, …, `CreateTriggers.sql`).
+- [**`metabrainz/musicbrainz-server/admin/`**](https://github.com/metabrainz/musicbrainz-server/tree/master/admin): `InitDb.pl` (authoritative DDL phase order) and `MBImport.pl` (reference for the COPY loop).
+- [**`metabrainz/musicbrainz-docker`**](https://github.com/metabrainz/musicbrainz-docker): upstream's official Docker-compose stack. A useful reference for how upstream provisions Postgres, but not a dependency of this tool.
+
+### Related Python tools
+
+- [**`acoustid/mbslave`**](https://github.com/acoustid/mbslave): Lukas Lalinsky's Python tool that handles both initial import and ongoing replication.
+- [**`acoustid/mbdata`**](https://github.com/acoustid/mbdata): SQLAlchemy models for the MusicBrainz schema. Complementary to this tool.
+
+### PostgreSQL
+
+- [**`postgres` Docker image**](https://hub.docker.com/_/postgres): the official image used in the Quick start.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Long-form companion to the [project README](../README.md). Everything here is re
 - [References](#references)
   - [MusicBrainz documentation](#musicbrainz-documentation)
   - [Upstream code](#upstream-code)
-  - [Related Python tools](#related-python-tools)
+  - [Related projects](#related-projects)
 
 ## PostgreSQL
 
@@ -119,22 +119,18 @@ Any libpq [environment variable](https://www.postgresql.org/docs/current/libpq-e
 
 ## References
 
-This tool is built on the following primary sources.
-
 ### MusicBrainz documentation
 
-- [**Database / Download**](https://wiki.musicbrainz.org/MusicBrainz_Database/Download): mirror layout, dump cadence, checksum/signature files.
-- [**Database / Schema**](https://wiki.musicbrainz.org/MusicBrainz_Database/Schema): PG version and extension requirements.
-- [**MusicBrainz Entity**](https://musicbrainz.org/doc/MusicBrainz_Entity): the entity model and which entities are core vs derived.
-- [**Development / JSON Data Dumps**](https://musicbrainz.org/doc/Development/JSON_Data_Dumps): JSON dump format (out of scope for this tool).
+- [Database / Download](https://wiki.musicbrainz.org/MusicBrainz_Database/Download): mirror layout, dump cadence, checksum/signature files.
+- [Database / Schema](https://wiki.musicbrainz.org/MusicBrainz_Database/Schema): PG version and extension requirements.
+- [MusicBrainz Entity](https://musicbrainz.org/doc/MusicBrainz_Entity): the entity model and which entities are core vs derived.
 
 ### Upstream code
 
-- [**`metabrainz/musicbrainz-server/admin/sql/`**](https://github.com/metabrainz/musicbrainz-server/tree/master/admin/sql): the canonical DDL this tool applies (`Extensions.sql`, `CreateCollations.sql`, `CreateTypes.sql`, `CreateTables.sql`, …, `CreateTriggers.sql`).
-- [**`metabrainz/musicbrainz-server/admin/`**](https://github.com/metabrainz/musicbrainz-server/tree/master/admin): `InitDb.pl` (authoritative DDL phase order) and `MBImport.pl` (reference for the COPY loop).
-- [**`metabrainz/musicbrainz-docker`**](https://github.com/metabrainz/musicbrainz-docker): upstream's official Docker-compose stack. A useful reference for how upstream provisions Postgres, but not a dependency of this tool.
+- [`metabrainz/musicbrainz-server/admin/`](https://github.com/metabrainz/musicbrainz-server/tree/master/admin): the upstream admin tree. Its [`sql/*.sql`](https://github.com/metabrainz/musicbrainz-server/tree/master/admin/sql) files are the canonical DDL we apply (`Extensions.sql`, `CreateCollations.sql`, `CreateTypes.sql`, `CreateTables.sql`, …, `CreateTriggers.sql`); `InitDb.pl` is the authoritative phase order; `MBImport.pl` is the reference for our COPY loop.
 
-### Related Python tools
+### Related projects
 
-- [**`acoustid/mbslave`**](https://github.com/acoustid/mbslave): Lukas Lalinsky's Python tool that handles both initial import and ongoing replication.
-- [**`acoustid/mbdata`**](https://github.com/acoustid/mbdata): SQLAlchemy models for the MusicBrainz schema. Complementary to this tool.
+- [`acoustid/mbslave`](https://github.com/acoustid/mbslave): Lukas Lalinsky's Python tool that handles both initial import and ongoing replication.
+- [`acoustid/mbdata`](https://github.com/acoustid/mbdata): SQLAlchemy models for the MusicBrainz schema. Complementary to this tool.
+- [`metabrainz/musicbrainz-docker`](https://github.com/metabrainz/musicbrainz-docker): upstream's official Docker-compose stack — useful reference for how upstream provisions Postgres.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,28 +1,26 @@
-# `musicbrainz-database-setup` — extended documentation
+# Reference guide
 
 Long-form companion to the [project README](../README.md). Everything here is reference material — the README covers the quick-start path; this file covers what you need once you outgrow it.
 
 ## Contents
 
-- [Requirements in detail](#requirements-in-detail)
-  - [PostgreSQL server](#postgresql-server)
-  - [PostgreSQL server-side tuning (optional)](#postgresql-server-side-tuning-optional)
-  - [PostgreSQL client (`psql`)](#postgresql-client-psql)
-  - [Parallel bz2 decompression (`pbzip2` / `lbzip2`, optional)](#parallel-bz2-decompression-pbzip2--lbzip2-optional)
-  - [Disk and memory](#disk-and-memory)
+- [PostgreSQL](#postgresql)
+  - [Server](#server)
+  - [Server-side tuning (optional)](#server-side-tuning-optional)
+  - [Client (`psql`)](#client-psql)
+- [Parallel bz2 decompression (`pbzip2` / `lbzip2`, optional)](#parallel-bz2-decompression-pbzip2--lbzip2-optional)
+- [Disk and memory](#disk-and-memory)
 - [Modules](#modules)
 - [Configuration](#configuration)
   - [Splitting the connection string](#splitting-the-connection-string)
-- [Progress output](#progress-output)
 - [References](#references)
   - [MusicBrainz documentation](#musicbrainz-documentation)
   - [Upstream code](#upstream-code)
   - [Related Python tools](#related-python-tools)
-  - [PostgreSQL](#postgresql)
 
-## Requirements in detail
+## PostgreSQL
 
-### PostgreSQL server
+### Server
 
 PostgreSQL **16 or later** with:
 
@@ -34,7 +32,7 @@ The tool pre-flights `pg_available_extensions` and `pg_collation` at startup and
 
 The tool also works against managed PostgreSQL (RDS, Cloud SQL, etc.) as long as the role you connect as can `CREATE EXTENSION` (on RDS that's `rds_superuser`; on Cloud SQL, `postgres`).
 
-### PostgreSQL server-side tuning (optional)
+### Server-side tuning (optional)
 
 Stock Postgres defaults (`shared_buffers=128 MB`, `maintenance_work_mem=64 MB`, `synchronous_commit=on`, `max_wal_size=1 GB`) leave significant performance on the table during index builds and constraint validation. The tool sets per-session tuning via `PGOPTIONS` for every `admin/sql/*.sql` invocation, but a handful of knobs can only be set at server start. If you're spinning up the Postgres container yourself, the following flags roughly halve post-import DDL time:
 
@@ -56,15 +54,15 @@ docker run -d --name musicbrainz-postgres \
 
 > ⚠️ **Memory sizing.** The tool applies `maintenance_work_mem=1GB` per psql session during DDL, and CREATE INDEX can fan out to `1 + max_parallel_maintenance_workers` workers each using that budget — up to **5 GB peak** on a single statement. Combined with `shared_buffers=2GB` above, that's ~7 GB of Postgres's own memory, fitting an 8 GB Docker Desktop VM with headroom for the OS and page cache. Raising `shared_buffers` beyond 2 GB on an 8 GB VM risks OOM kills during `CreateFKConstraints.sql` / `CreateConstraints.sql` — we hit this on 2026-04-24 with `shared_buffers=4GB`.
 
-### PostgreSQL client (`psql`)
+### Client (`psql`)
 
 The **`psql` client** must be available on `$PATH` on the machine running the tool. The upstream `admin/sql/*.sql` files use psql meta-commands (`\set ON_ERROR_STOP 1`, etc.) and manage their own `BEGIN;/COMMIT;` — we shell out to `psql` for each file, mirroring `admin/InitDb.pl`'s own approach, rather than reimplementing that parsing in Python. Install it with `brew install libpq` (macOS), `apt install postgresql-client` (Debian/Ubuntu), `apk add postgresql-client` (Alpine), or the equivalent on your distro.
 
-### Parallel bz2 decompression (`pbzip2` / `lbzip2`, optional)
+## Parallel bz2 decompression (`pbzip2` / `lbzip2`, optional)
 
 MusicBrainz dumps ship as `.tar.bz2`, and CPython's stdlib `bz2` module is single-threaded — the decompressor tops out around 35 MB/s of compressed input on a modern laptop, which pins one Python core at 100% and leaves the Postgres backend waiting on `Client/ClientRead` for most of the COPY phase. On a 14-core machine this made COPY the dominant cost of a fresh core-module import (14 m of 27 m total). If **`pbzip2`** or **`lbzip2`** is on `$PATH`, `open_archive()` pipes the archive through it instead, so decompression runs across multiple cores and the bottleneck shifts to Postgres (where it belongs). Install with `brew install pbzip2` (macOS), `apt install pbzip2` (Debian/Ubuntu), or `apk add pbzip2` (Alpine). If neither is present the tool falls back to the stdlib decompressor transparently — nothing fails, just slower.
 
-### Disk and memory
+## Disk and memory
 
 Expect **~10–15 GB** of downloads for `core`, **~30 GB** for `core + derived`, and the live database grows to roughly **100–160 GB** once indexes are built. More if `cover-art` or `event-art` are selected.
 
@@ -119,10 +117,6 @@ PGPASSWORD="$(op read op://work/musicbrainz/password)" \
 
 Any libpq [environment variable](https://www.postgresql.org/docs/current/libpq-envars.html) works the same way (`PGSSLMODE`, `PGSSLROOTCERT`, `PGCONNECT_TIMEOUT`, …).
 
-## Progress output
-
-The end-to-end `run` is structured as five phases — **Locate dump → Download → Schema setup → Import tables → Schema finalize** — each preceded by a `==> Phase N/5 · <label>` banner (Homebrew-style prefix) and closed by a `✓ <label> complete · <elapsed>` footer so the transcript shows where you are at a glance. Inside each phase, the body logs the mirror URL + resolved dump, the file list being downloaded, each `admin/sql/*.sql` applied (with `(N/total)` count prefix), and each COPY'd table by schema-qualified name. Standalone subcommands map to the relevant subset (`download` covers Locate dump + Download; `schema create --phase pre/post/all` covers Schema setup / Schema finalize; `import` covers Import tables). Routine progress lines have no level prefix (matching brew / cargo conventions); `Warning:` / `Error:` records keep an explicit text label so severity stays readable even with `--no-color`. Pass `-v` / `--verbose` to surface the underlying `httpx` HTTP requests and the rest of the DEBUG-level chatter; default output stays focused on phase progress.
-
 ## References
 
 This tool is built on the following primary sources.
@@ -144,7 +138,3 @@ This tool is built on the following primary sources.
 
 - [**`acoustid/mbslave`**](https://github.com/acoustid/mbslave): Lukas Lalinsky's Python tool that handles both initial import and ongoing replication.
 - [**`acoustid/mbdata`**](https://github.com/acoustid/mbdata): SQLAlchemy models for the MusicBrainz schema. Complementary to this tool.
-
-### PostgreSQL
-
-- [**`postgres` Docker image**](https://hub.docker.com/_/postgres): the official image used in the Quick start.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Long-form companion to the [project README](../README.md). Everything here is re
 - [Modules](#modules)
 - [Configuration](#configuration)
   - [Splitting the connection string](#splitting-the-connection-string)
+- [Progress output](#progress-output)
 - [References](#references)
   - [MusicBrainz documentation](#musicbrainz-documentation)
   - [Upstream code](#upstream-code)
@@ -117,6 +118,10 @@ PGPASSWORD="$(op read op://work/musicbrainz/password)" \
 ```
 
 Any libpq [environment variable](https://www.postgresql.org/docs/current/libpq-envars.html) works the same way (`PGSSLMODE`, `PGSSLROOTCERT`, `PGCONNECT_TIMEOUT`, …).
+
+## Progress output
+
+The end-to-end `run` is structured as five phases — **Locate dump → Download → Schema setup → Import tables → Schema finalize** — each preceded by a `==> Phase N/5 · <label>` banner (Homebrew-style prefix) and closed by a `✓ <label> complete · <elapsed>` footer so the transcript shows where you are at a glance. Inside each phase, the body logs the mirror URL + resolved dump, the file list being downloaded, each `admin/sql/*.sql` applied (with `(N/total)` count prefix), and each COPY'd table by schema-qualified name. Standalone subcommands map to the relevant subset (`download` covers Locate dump + Download; `schema create --phase pre/post/all` covers Schema setup / Schema finalize; `import` covers Import tables). Routine progress lines have no level prefix (matching brew / cargo conventions); `Warning:` / `Error:` records keep an explicit text label so severity stays readable even with `--no-color`. Pass `-v` / `--verbose` to surface the underlying `httpx` HTTP requests and the rest of the DEBUG-level chatter; default output stays focused on phase progress.
 
 ## References
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,102 @@
+# `musicbrainz-database-setup` — extended documentation
+
+Long-form companion to the [project README](../README.md). Everything here is reference material — the README covers the quick-start path; this file covers what you need once you outgrow it.
+
+## Requirements in detail
+
+### PostgreSQL server
+
+PostgreSQL **16 or later** with:
+
+- The **`cube`**, **`earthdistance`**, and **`unaccent`** extensions — declared in upstream [`admin/sql/Extensions.sql`](https://github.com/metabrainz/musicbrainz-server/blob/master/admin/sql/Extensions.sql). They ship with the `postgresql-contrib` package, which is bundled in every official [`postgres:*` Docker image](https://hub.docker.com/_/postgres).
+- **ICU support** (server built with `--with-icu`). The MusicBrainz collation in [`admin/sql/CreateCollations.sql`](https://github.com/metabrainz/musicbrainz-server/blob/master/admin/sql/CreateCollations.sql) uses `provider = icu`. Every official `postgres:*` image since PG 16 qualifies.
+- A role with **`SUPERUSER`** privileges so the tool can `CREATE EXTENSION`. The default `postgres` user created by the official image works.
+
+The tool pre-flights `pg_available_extensions` and `pg_collation` at startup and aborts with an actionable message if anything is missing.
+
+The tool also works against managed PostgreSQL (RDS, Cloud SQL, etc.) as long as the role you connect as can `CREATE EXTENSION` (on RDS that's `rds_superuser`; on Cloud SQL, `postgres`).
+
+### PostgreSQL server-side tuning (optional)
+
+Stock Postgres defaults (`shared_buffers=128 MB`, `maintenance_work_mem=64 MB`, `synchronous_commit=on`, `max_wal_size=1 GB`) leave significant performance on the table during index builds and constraint validation. The tool sets per-session tuning via `PGOPTIONS` for every `admin/sql/*.sql` invocation, but a handful of knobs can only be set at server start. If you're spinning up the Postgres container yourself, the following flags roughly halve post-import DDL time:
+
+```bash
+docker run -d --name musicbrainz-postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -p 5432:5432 \
+  postgres:17-alpine \
+  -c shared_buffers=2GB \
+  -c max_wal_size=8GB \
+  -c checkpoint_timeout=30min \
+  -c effective_io_concurrency=200 \
+  -c random_page_cost=1.1
+```
+
+- `shared_buffers=2GB` — default 128 MB forces constant disk re-reads during CHECK/FK full-table scans; at 2 GB the hot tables fit in cache without starving the rest of the 8 GB Docker Desktop VM. (If your VM has more RAM, you can safely push this to `4GB`.)
+- `max_wal_size=8GB` + `checkpoint_timeout=30min` — default 1 GB / 5 min triggers checkpoints every couple of minutes during COPY.
+- `effective_io_concurrency=200` + `random_page_cost=1.1` — signal to the planner that the underlying storage (Docker named volume on SSD) isn't a spinning disk.
+
+> ⚠️ **Memory sizing.** The tool applies `maintenance_work_mem=1GB` per psql session during DDL, and CREATE INDEX can fan out to `1 + max_parallel_maintenance_workers` workers each using that budget — up to **5 GB peak** on a single statement. Combined with `shared_buffers=2GB` above, that's ~7 GB of Postgres's own memory, fitting an 8 GB Docker Desktop VM with headroom for the OS and page cache. Raising `shared_buffers` beyond 2 GB on an 8 GB VM risks OOM kills during `CreateFKConstraints.sql` / `CreateConstraints.sql` — we hit this on 2026-04-24 with `shared_buffers=4GB`.
+
+### PostgreSQL client (`psql`)
+
+The **`psql` client** must be available on `$PATH` on the machine running the tool. The upstream `admin/sql/*.sql` files use psql meta-commands (`\set ON_ERROR_STOP 1`, etc.) and manage their own `BEGIN;/COMMIT;` — we shell out to `psql` for each file, mirroring `admin/InitDb.pl`'s own approach, rather than reimplementing that parsing in Python. Install it with `brew install libpq` (macOS), `apt install postgresql-client` (Debian/Ubuntu), `apk add postgresql-client` (Alpine), or the equivalent on your distro.
+
+### Parallel bz2 decompression (`pbzip2` / `lbzip2`, optional)
+
+MusicBrainz dumps ship as `.tar.bz2`, and CPython's stdlib `bz2` module is single-threaded — the decompressor tops out around 35 MB/s of compressed input on a modern laptop, which pins one Python core at 100% and leaves the Postgres backend waiting on `Client/ClientRead` for most of the COPY phase. On a 14-core machine this made COPY the dominant cost of a fresh core-module import (14 m of 27 m total). If **`pbzip2`** or **`lbzip2`** is on `$PATH`, `open_archive()` pipes the archive through it instead, so decompression runs across multiple cores and the bottleneck shifts to Postgres (where it belongs). Install with `brew install pbzip2` (macOS), `apt install pbzip2` (Debian/Ubuntu), or `apk add pbzip2` (Alpine). If neither is present the tool falls back to the stdlib decompressor transparently — nothing fails, just slower.
+
+### Disk and memory
+
+Expect **~10–15 GB** of downloads for `core`, **~30 GB** for `core + derived`, and the live database grows to roughly **100–160 GB** once indexes are built. More if `cover-art` or `event-art` are selected.
+
+Memory is comfortable at **8 GB** for the Postgres container with the tuning above (`shared_buffers=2GB` + the per-session `maintenance_work_mem=1GB` applied during DDL); **16 GB** if you're running the client and the database on the same machine. CPython's stdlib `bz2` fallback adds no client-side memory pressure; `pbzip2` uses a small fixed buffer per thread.
+
+## Modules
+
+The MusicBrainz database is split across several `.tar.bz2` archives on the mirror — enumerated canonically, with contents, licensing, and release cadence, on the [MusicBrainz Database / Download wiki page](https://wiki.musicbrainz.org/MusicBrainz_Database/Download).
+
+`--modules` (comma-separated) selects which to download and import; `core` is the default and the others are opt-in. Example: `--modules core,derived,cover-art`.
+
+| Module | Target schema | Contents |
+|---|---|---|
+| `core` | `musicbrainz` | Core MusicBrainz database — tables for Artist, Release, Recording, etc. Most catalog use cases only need this plus `derived`. |
+| `derived` | `musicbrainz` | Annotations, user ratings, user tags, and search indexes. Required for genre data (genres are stored as user tags). Annotations FK to editors, so add `editor` for standalone (non-mirror) setups. |
+| `editor` | `musicbrainz` | Non-personal user data about the people who enacted the edits in the edit history. |
+| `edit` | `musicbrainz` | Complete edit history for the core database — open and closed edits, edit notes, votes, and auto-editor elections. Editor identity comes from the `editor` dump. |
+| `cover-art` | `cover_art_archive` | Tables linking MusicBrainz to the [Cover Art Archive](https://wiki.musicbrainz.org/Cover_Art_Archive) (metadata only — no images). |
+| `event-art` | `event_art_archive` | Tables linking MusicBrainz to the [Event Art Archive](https://wiki.musicbrainz.org/Event_Art_Archive) (metadata only — no images). |
+| `stats` | `statistics` | Site statistics — the data behind [musicbrainz.org/statistics](https://musicbrainz.org/statistics). |
+| `documentation` | `documentation` | Tables specifying which relationships are used as examples for each relationship type, plus per-type guidelines where available. |
+| `wikidocs` | `wikidocs` | The `wikidocs_index` table — which revision is transcluded for each page in the [WikiDocs](https://wiki.musicbrainz.org/WikiDocs) system. |
+| `cdstubs` | `musicbrainz` | [CD Stubs](https://wiki.musicbrainz.org/CD_Stub) — anonymously submitted, treated as an untrusted source kept separate from the core database. |
+
+## Configuration
+
+Precedence: CLI flags > env vars > `.env` file > defaults.
+
+| Variable | Meaning |
+|---|---|
+| `MUSICBRAINZ_DATABASE_SETUP_DB_URL` | libpq connection URL |
+| `MUSICBRAINZ_DATABASE_SETUP_MIRROR_URL` | Base URL of the dump mirror |
+| `MUSICBRAINZ_DATABASE_SETUP_SQL_REF` | Git ref (branch/tag/SHA) for the `admin/sql/*.sql` fetch. Default `master`; pin to a `v-NN-schema-change` tag for reproducibility. |
+| `MUSICBRAINZ_DATABASE_SETUP_WORKDIR` | Local cache dir for archive downloads. Default `${XDG_CACHE_HOME:-~/.cache}/musicbrainz-database-setup/dumps`. |
+| `MUSICBRAINZ_DATABASE_SETUP_SQL_CACHE_DIR` | Local cache dir for fetched `admin/sql/*.sql` files, keyed by resolved commit SHA. Default `${XDG_CACHE_HOME:-~/.cache}/musicbrainz-database-setup/sql`. |
+| `MUSICBRAINZ_DATABASE_SETUP_MODULES` | Comma-separated list of modules to download and import (e.g. `core,derived,cover-art`). See [Modules](#modules). Default `core`. |
+
+### Splitting the connection string
+
+libpq (used by both psycopg3 and `psql`) natively honors the `PG*` environment variables — values omitted from the connection URL fall back to them. This lets you keep connection coordinates and secrets in separate places. Hard-code host/port/user/database in a committed `.env`:
+
+```bash
+MUSICBRAINZ_DATABASE_SETUP_DB_URL=postgresql://postgres@localhost:5432/postgres
+```
+
+…and supply the password at runtime from a secret manager or your shell:
+
+```bash
+PGPASSWORD="$(op read op://work/musicbrainz/password)" \
+  uv run musicbrainz-database-setup run --latest
+```
+
+Any libpq [environment variable](https://www.postgresql.org/docs/current/libpq-envars.html) works the same way (`PGSSLMODE`, `PGSSLROOTCERT`, `PGCONNECT_TIMEOUT`, …).


### PR DESCRIPTION
## Summary

- **Trim README from ~260 → ~190 lines** so a first-time visitor reaches Quick start above the fold. Move reference-heavy content (Requirements in detail, Modules table, Configuration env vars + libpq-split section) to a new **`docs/README.md`** long-form companion.
- **Rewrite "Poke around the imported data"**: connect via `psql postgresql://…` directly (psql is already a Requirements bullet) instead of `docker exec -it musicbrainz-postgres psql`. Replace the toy Beatles lookup with a worked **[Django Reinhardt](https://musicbrainz.org/artist/650bf385-6f6d-4992-a3b9-779d144920a4)** example — artist details (joining `gender` / `artist_type` / `area`) and external links via the URL relationship system (`l_artist_url` → `link` → `link_type` → `url`). Wikidata ID [Q44122](https://www.wikidata.org/wiki/Q44122) called out and linked.
- **Misc DX touches**: tighten intro paragraphs (rephrase RAGtime origin); drop the disk-size bullet from Requirements (now in `docs/README.md` → Disk and memory); update the optional-tuning callout to point at `docs/README.md#postgresql-server-side-tuning-optional`. No orphaned anchors remain.

Rubric for the trim: progressive-disclosure guidance from [awesome-readme](https://github.com/matiassingers/awesome-readme), [makeareadme.com](https://www.makeareadme.com/), and [GitHub Docs · About READMEs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes).

## Test plan

- [x] Both new SQL blocks executed against a live core-module import: Query A returns Django Reinhardt (Male / Person / 1910 / 1953 / France); Query B returns 33 link types incl. `wikidata` → https://www.wikidata.org/wiki/Q44122.
- [x] `grep -nE '#requirements-in-detail|#postgresql-server-side-tuning-optional|docker exec -it' README.md` returns only the new (correct) `docs/README.md#postgresql-server-side-tuning-optional` pointer.
- [x] `git diff --stat` confirms only `README.md` modified + `docs/README.md` added; no other files touched.
- [x] Render preview on GitHub: anchors `docs/README.md#requirements-in-detail`, `#modules`, `#configuration`, `#postgresql-server-side-tuning-optional` resolve; the new external links (MusicBrainz artist page + Wikidata) render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)