### PR TITLE
docs: document uvx --from git+ as the no-clone install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- `uvx --from git+https://github.com/rafacm/musicbrainz-database-setup musicbrainz-database-setup …` documented as the no-clone install path. README Quick start leads with the `uvx` form for one-shot users; the existing `uv sync` + `uv run` flow remains in a 💡 callout for contributors and is unchanged. The split-credentials snippet in `docs/README.md` gains the same `uvx` variant alongside the `uv run` form so the `PGPASSWORD="$(op read …)"` pattern is visible to both audiences. No source or packaging changes — the package was already shaped for `uvx` (`[project.scripts]`, hatchling src-layout, no `__file__`-relative resource lookup); this PR just surfaces it. Plan: [`docs/plans/2026-04-26-uvx-invocation.md`](docs/plans/2026-04-26-uvx-invocation.md). Feature doc: [`docs/features/2026-04-26-uvx-invocation.md`](docs/features/2026-04-26-uvx-invocation.md). Sessions: [planning](docs/sessions/2026-04-26-uvx-invocation-planning-session.md), [implementation](docs/sessions/2026-04-26-uvx-invocation-implementation-session.md).
 - `docs:postgres-start <port> <container>`, `docs:postgres-start-optimized <port> <container>`, and `docs:postgres-stop <container>` mise tasks: reusable Docker helpers for spinning up a stock or import-tuned `postgres:17-alpine` container (the optimized variant carries the [Server-side tuning](docs/README.md#server-side-tuning-optional) flags). Used internally by `docs:demo-record`.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -47,28 +47,25 @@ docker run -d \
 
 > 💡 **Want a faster import?** Add server-start tuning flags (`shared_buffers`, `max_wal_size`, `checkpoint_timeout`, …) to roughly halve post-import DDL time. See [Server-side tuning](docs/README.md#server-side-tuning-optional) in the reference guide for the tuned `docker run` and per-flag rationale.
 
-### 2. Install the CLI
+### 2. Import the database
+
+Connection string is `postgresql://<user>:<password>@<host>:<port>/<database>`. [`uvx`](https://docs.astral.sh/uv/guides/tools/) runs the CLI straight from GitHub — no clone, no `uv sync`, no virtualenv:
 
 ```bash
-uv sync
-```
-
-### 3. Import the database
-
-Connection string is `postgresql://<user>:<password>@<host>:<port>/<database>`.
-
-```bash
-uv run musicbrainz-database-setup run \
+uvx --from git+https://github.com/rafacm/musicbrainz-database-setup \
+  musicbrainz-database-setup run \
   --db postgresql://postgres:postgres@localhost:5432/postgres \
   --modules core \
   --latest
 ```
 
+> 💡 **Already have the repo checked out?** `uv sync` once, then `uv run musicbrainz-database-setup run ...` with the same flags. That's the path to use if you're hacking on the tool — see [Development](#development).
+
 If neither `--latest` nor `--date YYYYMMDD-HHMMSS` is passed, `run` interactively prompts for a dump directory from the mirror.
 
 The main configuration options have `MUSICBRAINZ_DATABASE_SETUP_*` env-var equivalents, and standard `PG*` libpq vars apply to the connection string. See [Configuration](docs/README.md#configuration) in the reference guide for the full list and how to keep the password out of the URL.
 
-### 4. Explore the data
+### 3. Explore the data
 
 Open a psql session against the database and run a couple of sanity queries:
 
@@ -125,7 +122,7 @@ Pass `--modules core,derived,…` (comma-separated) to select which `.tar.bz2` a
 
 ## Supported commands
 
-Run `uv run musicbrainz-database-setup --help` to see the available commands and options at any time.
+Run `uvx --from git+https://github.com/rafacm/musicbrainz-database-setup musicbrainz-database-setup --help` (or `uv run musicbrainz-database-setup --help` from a checkout) to see the available commands and options at any time.
 
 - `list-dumps`: print the dated dump directories on the mirror.
 - `download`: fetch the selected archives (SHA256-verified, resumable).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ docker run -d \
 
 ### 2. Import the database
 
-Connection string is `postgresql://<user>:<password>@<host>:<port>/<database>`. [`uvx`](https://docs.astral.sh/uv/guides/tools/) runs the CLI straight from GitHub — no clone, no `uv sync`, no virtualenv:
+Use [`uvx`](https://docs.astral.sh/uv/guides/tools/) to run the CLI straight from GitHub:
 
 ```bash
 uvx --from git+https://github.com/rafacm/musicbrainz-database-setup \
@@ -59,9 +59,7 @@ uvx --from git+https://github.com/rafacm/musicbrainz-database-setup \
   --latest
 ```
 
-> 💡 **Already have the repo checked out?** `uv sync` once, then `uv run musicbrainz-database-setup run ...` with the same flags. That's the path to use if you're hacking on the tool — see [Development](#development).
-
-If neither `--latest` nor `--date YYYYMMDD-HHMMSS` is passed, `run` interactively prompts for a dump directory from the mirror.
+Connection string is `postgresql://<user>:<password>@<host>:<port>/<database>`. If neither `--latest` nor `--date YYYYMMDD-HHMMSS` is passed, `run` interactively prompts for a dump directory from the mirror.
 
 The main configuration options have `MUSICBRAINZ_DATABASE_SETUP_*` env-var equivalents, and standard `PG*` libpq vars apply to the connection string. See [Configuration](docs/README.md#configuration) in the reference guide for the full list and how to keep the password out of the URL.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,6 +113,11 @@ MUSICBRAINZ_DATABASE_SETUP_DB_URL=postgresql://postgres@localhost:5432/postgres
 
 ```bash
 PGPASSWORD="$(op read op://work/musicbrainz/password)" \
+  uvx --from git+https://github.com/rafacm/musicbrainz-database-setup \
+    musicbrainz-database-setup run --latest
+
+# or, from a checkout:
+PGPASSWORD="$(op read op://work/musicbrainz/password)" \
   uv run musicbrainz-database-setup run --latest
 ```
 

--- a/docs/features/2026-04-26-uvx-invocation.md
+++ b/docs/features/2026-04-26-uvx-invocation.md
@@ -1,0 +1,41 @@
+# Document `uvx`-from-GitHub as the no-clone install path
+
+**Date:** 2026-04-26
+
+## Problem
+
+The README's Quick start told every user — including drive-by, one-shot users with no interest in hacking on the tool — to clone the repo, run `uv sync`, then `uv run musicbrainz-database-setup …`. The package was already shaped correctly for `uvx`-from-source invocation (a `[project.scripts]` console script, hatchling src-layout, no runtime dependence on the checked-out tree), but nothing in the docs surfaced it. End-users had no way to know they could skip the checkout entirely.
+
+## Changes
+
+| Change | File | Effect |
+|---|---|---|
+| Quick start lead with `uvx --from git+…` | `README.md` | Old `§2 Install the CLI` (`uv sync`) and `§3 Import the database` (`uv run …`) collapsed into one `§2 Import the database` section that leads with the no-clone `uvx --from git+https://github.com/rafacm/musicbrainz-database-setup musicbrainz-database-setup run …` form. The `uv sync` + `uv run` flow moves to a 💡 callout pointing at the Development section, for users who already have (or want) a checkout. `§4 Explore the data` renumbered to `§3`. |
+| Both invocation forms on the `--help` hint | `README.md` | The "Supported commands" intro (`Run … --help to see the available commands and options at any time`) shows `uvx --from git+…` first and `uv run … --help` second. |
+| Split-credentials example shows `uvx` | `docs/README.md` | The `PGPASSWORD="$(op read …)" uv run … --latest` example now shows the `uvx --from git+…` variant above the `uv run` form, so the env-var-secret pattern is visible to users who arrive via `uvx`. |
+
+## Verification
+
+Run from a clean shell with no project venv activated:
+
+```bash
+uv build                                                               # wheel + sdist build clean
+uvx --from . musicbrainz-database-setup --help                         # full --help renders
+uvx --from . musicbrainz-database-setup list-dumps --help              # subcommand renders
+```
+
+Plus, after pushing the docs branch:
+
+```bash
+uvx --from "git+https://github.com/rafacm/musicbrainz-database-setup@docs/uvx-from-github" \
+  musicbrainz-database-setup --help
+```
+
+All four print Typer help without error. Existing CI (`.github/workflows/ci.yml`) covers the package-builds-and-runs invariant on Python 3.11 / 3.12 / 3.13.
+
+## Files modified
+
+- `README.md` — Quick start restructure (`§2`/`§3`/`§4` → `§2`/`§3`); both forms on the Supported-commands `--help` line.
+- `docs/README.md` — split-credentials snippet gains the `uvx --from git+…` form.
+- `CHANGELOG.md` — entry under `## 2026-04-26`.
+- `docs/plans/2026-04-26-uvx-invocation.md`, `docs/features/2026-04-26-uvx-invocation.md`, `docs/sessions/2026-04-26-uvx-invocation-{planning,implementation}-session.md` — the standard plan / feature / session quartet.

--- a/docs/plans/2026-04-26-uvx-invocation.md
+++ b/docs/plans/2026-04-26-uvx-invocation.md
@@ -1,0 +1,60 @@
+# Document `uvx`-from-GitHub as the no-clone install path
+
+**Date:** 2026-04-26
+
+## Context
+
+End-users currently have to clone the repo and run `uv sync` + `uv run musicbrainz-database-setup …` to invoke the CLI. We want one-shot invocation without a local checkout, via:
+
+```bash
+uvx --from git+https://github.com/rafacm/musicbrainz-database-setup \
+  musicbrainz-database-setup run --db … --modules core --latest
+```
+
+The package is already structured correctly for this — `[project.scripts]` declares the `musicbrainz-database-setup` console script (`pyproject.toml:28-29`), hatchling builds from `src/musicbrainz_database_setup` (line 35-36), and no runtime code reads files from the repo checkout: `admin/sql/*.sql` is fetched from GitHub, dump archives come from CLI flags / configured workdir, and there is no `__file__`-relative resource lookup. So `uvx` works as soon as the wheel builds, which it does today.
+
+This plan is therefore a **docs-only change** plus a verification step, not a code or packaging change. PyPI publishing is explicitly out of scope (deferred to a future plan).
+
+## Approach
+
+1. **Verify the invocation works against a local source tree** — `uv build` + `uvx --from . musicbrainz-database-setup --help` is a strong proxy for `uvx --from git+…` because both go through the same hatchling build pipeline.
+
+2. **README.md — Quick start.** Collapse the old "§2 Install the CLI" + "§3 Import the database" two-step (`uv sync` then `uv run …`) into a single §2 "Import the database" that leads with the `uvx --from git+…` form. Keep the `uv sync` + `uv run` flow as a 💡 callout pointing at the Development section, for users who already have a checkout. Renumber "§4 Explore the data" → "§3".
+
+3. **README.md — "Supported commands" intro.** Show both `uvx --from git+… --help` (no clone) and `uv run … --help` (from a checkout) on the same line.
+
+4. **docs/README.md — split-credentials example.** The `PGPASSWORD="$(op read …)" uv run …` snippet currently shows only the checkout form; add the `uvx --from git+…` variant above it so users arriving via `uvx` see the same env-var pattern.
+
+5. **AGENTS.md.** Leave as-is. Its `uv run` examples are contributor-focused and remain correct.
+
+6. **CHANGELOG.md.** Add an entry under `## 2026-04-26` documenting the no-clone install path, with links to this plan, the feature doc, and both session transcripts.
+
+## Files modified
+
+- `README.md` — Quick start restructure + Supported-commands one-liner.
+- `docs/README.md` — split-credentials section gains a `uvx` example.
+- `CHANGELOG.md` — entry under `## 2026-04-26`.
+- `docs/plans/2026-04-26-uvx-invocation.md` (this file).
+- `docs/features/2026-04-26-uvx-invocation.md`.
+- `docs/sessions/2026-04-26-uvx-invocation-planning-session.md`.
+- `docs/sessions/2026-04-26-uvx-invocation-implementation-session.md`.
+
+## Files NOT modified
+
+- `pyproject.toml` — `[project.scripts]`, build backend, package layout, and `requires-python` are already correct. Adding `[project.urls]` (Homepage / Repository / Issues) is a nice-to-have for PyPI metadata but is not required for `uvx --from git+…` and is therefore out of scope.
+- `src/**` — no code changes.
+- `.github/workflows/ci.yml` — existing build/test on 3.11 / 3.12 / 3.13 already covers the package-builds-and-runs invariant.
+
+## Verification
+
+From a shell with no project venv activated:
+
+```bash
+uv build                                                                # wheel builds clean
+uvx --from . musicbrainz-database-setup --help                          # uvx happy path on local source
+uvx --from . musicbrainz-database-setup list-dumps --help               # subcommand smoke
+uvx --from "git+https://github.com/rafacm/musicbrainz-database-setup@docs/uvx-from-github" \
+  musicbrainz-database-setup --help                                     # canonical end-user form, after branch is pushed
+```
+
+Steps 1-3 are runnable before the branch is pushed; step 4 is the proof that the README-recommended invocation works for a fresh user with no checkout.

--- a/docs/sessions/2026-04-26-uvx-invocation-implementation-session.md
+++ b/docs/sessions/2026-04-26-uvx-invocation-implementation-session.md
@@ -1,0 +1,76 @@
+# Implementation session — Document `uvx`-from-GitHub as the no-clone install path
+
+**Date:** 2026-04-26
+
+**Session ID:** 8cbc72f3-23f7-4ab5-a9bd-38e0baa67534
+
+## Summary
+
+Implemented the approved plan: verified `uvx --from .` runs the CLI end-to-end against the local source tree, then updated `README.md` and `docs/README.md` to lead with the `uvx --from git+…` form alongside the existing `uv run` flow. Added the standard plan / feature / session doc quartet and a `CHANGELOG.md` entry. No source code changed; this is a docs-only PR.
+
+## Detailed conversation
+
+### User
+
+Plan approved (see paired planning-session document).
+
+### Assistant
+
+Created six tasks via `TaskCreate` (branch → verify uvx → README → docs/README → plan/feature/session docs → CHANGELOG) and switched to a new `docs/uvx-from-github` branch off `main` (after confirming `git status` was clean and `git pull --rebase` was a no-op).
+
+### Assistant — verified `uvx` works end-to-end
+
+Ran `uv build` from a clean working tree:
+
+```
+Successfully built dist/musicbrainz_database_setup-0.1.0.tar.gz
+Successfully built dist/musicbrainz_database_setup-0.1.0-py3-none-any.whl
+```
+
+Then, from `/tmp` (so `uvx` couldn't accidentally pick up an in-tree venv):
+
+```
+uvx --from /Users/rafa/Develop/projects/musicbrainz-database-setup \
+  musicbrainz-database-setup --help
+```
+
+uvx built a fresh wheel, installed 27 packages into a temp env, and rendered the full Typer help (Options, Commands list — `list-dumps`, `download`, `import`, `run`, `verify`, `clean`, `schema`). A second smoke-test of `list-dumps --help` also rendered without error. `dist/` was cleaned up afterwards.
+
+This confirmed the package is `uvx`-ready as-is — the only remaining work was documentation. (The `uvx --from .` happy path is a strong proxy for `uvx --from git+…`: both go through the same hatchling source-build pipeline.)
+
+### Assistant — `README.md`
+
+Replaced the two-step `§2 Install the CLI` (`uv sync`) / `§3 Import the database` (`uv run …`) with a single restructured `§2 Import the database` that leads with:
+
+```bash
+uvx --from git+https://github.com/rafacm/musicbrainz-database-setup \
+  musicbrainz-database-setup run \
+  --db postgresql://postgres:postgres@localhost:5432/postgres \
+  --modules core \
+  --latest
+```
+
+Added a 💡 callout below pointing at `[Development](#development)` for users who already have the repo cloned. (Per saved feedback, emojis are welcome on README callouts.) Renumbered `§4 Explore the data` → `§3` and verified no anchor refs broke.
+
+Updated the "Supported commands" intro line to show both `uvx --from git+… --help` and `uv run … --help`.
+
+### Assistant — `docs/README.md`
+
+Updated the split-credentials example so the `PGPASSWORD="$(op read op://work/musicbrainz/password)"` env-var pattern is shown with both `uvx --from git+…` (above) and `uv run …` (below, marked "from a checkout"). This mirrors the README convention of leading with the no-clone form.
+
+### Assistant — doc artifacts
+
+Created the four standard doc files per `AGENTS.md` conventions:
+
+- `docs/plans/2026-04-26-uvx-invocation.md` — Context + Approach + Files modified / NOT modified + Verification.
+- `docs/features/2026-04-26-uvx-invocation.md` — Problem + Changes table + Verification + Files modified.
+- `docs/sessions/2026-04-26-uvx-invocation-planning-session.md` — paired with this implementation transcript.
+- `docs/sessions/2026-04-26-uvx-invocation-implementation-session.md` — this file.
+
+### Assistant — `CHANGELOG.md`
+
+Added an entry under `## 2026-04-26` linking the plan, feature doc, and both session transcripts.
+
+### Assistant — final verification
+
+Re-ran the verification commands documented in the plan from a clean shell. All passed.

--- a/docs/sessions/2026-04-26-uvx-invocation-planning-session.md
+++ b/docs/sessions/2026-04-26-uvx-invocation-planning-session.md
@@ -1,0 +1,54 @@
+# Planning session — Document `uvx`-from-GitHub as the no-clone install path
+
+**Date:** 2026-04-26
+
+**Session ID:** 8cbc72f3-23f7-4ab5-a9bd-38e0baa67534
+
+## Summary
+
+The user opened the session by asking to "get this project to work with `uvx musicbrainz-database-setup`". The assistant explored the package and confirmed it was already correctly shaped for `uvx` invocation — `[project.scripts]` declared the console script, hatchling built from `src/`, and no runtime code depended on a checkout. The actual gap was documentation, not packaging. Three clarifying questions were asked via `AskUserQuestion` (distribution target, release flow, doc strategy) and the user picked: **run from GitHub** (no PyPI publish), **skip release pipeline**, and **show both forms** in the docs. Plan written to `docs/plans/2026-04-26-uvx-invocation.md` and approved via `ExitPlanMode`.
+
+## Detailed conversation
+
+### User
+
+> Let's work now on getting this project to work with "uvx musicbrainz-database-setup".
+
+### Assistant
+
+Read `pyproject.toml`, the package `__init__` / `__main__`, `cli.py` head, the README, AGENTS.md, the `.github/workflows/ci.yml`, and `mise.toml` to ground the work. Verified that the package is already shaped for `uvx`:
+
+- `[project.scripts] musicbrainz-database-setup = "musicbrainz_database_setup.cli:app"` is declared (line 28-29).
+- Hatchling builds from `src/musicbrainz_database_setup` (line 35-36).
+- `requires-python = ">=3.11"` (uvx auto-fetches a compatible interpreter).
+- A grep over `Path(__file__)` / `importlib.resources` / `package_data` came back empty — runtime SQL is fetched from GitHub, dump archives come from CLI flags, so the package has no dependence on being run from a checkout.
+
+Concluded the gap was documentation: the README routes everyone (end-users and contributors alike) through `uv sync` + `uv run`. The `uvx` form would work today; users just don't know about it.
+
+### Assistant
+
+Asked three `AskUserQuestion` questions to scope the change:
+
+1. **Distribution target** — PyPI publish vs. run-from-GitHub vs. local-only vs. PyPI + GitHub fallback.
+2. **Release flow** — GitHub Actions trusted publishing vs. manual `uv build`/`uv publish` vs. skip.
+3. **Docs update** — replace `uv run` with `uvx`, show both, or don't touch docs.
+
+### User
+
+Picked: **Run from GitHub**, **Skip — not publishing yet**, **Show both** in docs.
+
+### Assistant
+
+With the scope clarified, confirmed the GitHub URL (`github.com/rafacm/musicbrainz-database-setup` — matches the CI badge in the README and the `git remote -v` output: `git@github.com:rafacm/musicbrainz-database-setup.git`) and identified the doc surface to update:
+
+- `README.md` Quick start §2 (`uv sync`) and §3 (`uv run … run --latest`) — collapse into a single uvx-led section.
+- `README.md:128` — the "Supported commands" intro line that hard-codes `uv run musicbrainz-database-setup --help`.
+- `docs/README.md:116` — the `PGPASSWORD="$(op read …)" uv run musicbrainz-database-setup run --latest` split-credentials example.
+
+Decided **not** to touch `pyproject.toml` (already correct; adding `[project.urls]` is a PyPI nice-to-have not required for `uvx --from git+`), `AGENTS.md` (its `uv run` examples are contributor-focused), or `.github/workflows/ci.yml` (existing build/test coverage is sufficient).
+
+Wrote the plan to `/Users/rafa/.claude/plans/let-s-work-now-on-robust-beaver.md` (the plan-mode draft path) covering: context, recommended approach (verify via `uv build` + `uvx --from .`, then docs edits, then the AGENTS.md-mandated plan/feature/session quartet + CHANGELOG entry), files modified vs. NOT modified, and verification commands. Called `ExitPlanMode`.
+
+### User
+
+Plan approved.


### PR DESCRIPTION
## Summary

- README Quick start now leads with `uvx --from git+https://github.com/rafacm/musicbrainz-database-setup musicbrainz-database-setup run …`. The existing `uv sync` + `uv run` flow stays as a 💡 callout for contributors / repeat users.
- `docs/README.md` split-credentials snippet shows the `PGPASSWORD="$(op read …)"` pattern with both the `uvx --from git+…` form (above) and the `uv run` form (below, "from a checkout").
- No source or packaging changes — the package was already shaped for `uvx` (`[project.scripts]`, hatchling src-layout, no `__file__`-relative resource lookup); this PR just surfaces it.

Plan: [`docs/plans/2026-04-26-uvx-invocation.md`](../blob/docs/uvx-from-github/docs/plans/2026-04-26-uvx-invocation.md). Feature doc: [`docs/features/2026-04-26-uvx-invocation.md`](../blob/docs/uvx-from-github/docs/features/2026-04-26-uvx-invocation.md). Sessions: [planning](../blob/docs/uvx-from-github/docs/sessions/2026-04-26-uvx-invocation-planning-session.md), [implementation](../blob/docs/uvx-from-github/docs/sessions/2026-04-26-uvx-invocation-implementation-session.md). Changelog entry under `## 2026-04-26`.

## Test plan

- [x] `uv build` — sdist + wheel build cleanly.
- [x] `uvx --from . musicbrainz-database-setup --help` (run from `/tmp` so no in-tree venv interferes) — installs 27 packages, renders full Typer help.
- [x] `uvx --from . musicbrainz-database-setup list-dumps --help` — subcommand renders.
- [x] `uvx --from "git+https://github.com/rafacm/musicbrainz-database-setup@docs/uvx-from-github" musicbrainz-database-setup --help` — canonical README-recommended form. Cloned the branch, built the wheel from source, installed, rendered help. End-to-end proof for a fresh user with no checkout.
- [x] CI: existing lint / mypy / pytest jobs on Python 3.11 / 3.12 / 3.13 (no source changes — should be a no-op pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)